### PR TITLE
fast construction and indexing

### DIFF
--- a/src/StaticBitArrays.jl
+++ b/src/StaticBitArrays.jl
@@ -5,44 +5,59 @@ const SA = StaticArrays
 
 export SBitVector, SBitMatrix, SBitArray
 
-struct SBitArray{S,M,T<:Unsigned,N,L} <: StaticArray{S,Bool,N}
+struct SBitArray{S,C,T<:Unsigned,N,L} <: StaticArray{S,Bool,N}
     # type signiture: {Length, ChunksLength, ChunksType}
-    chunks::SVector{M,T}
-    function SBitArray{S}(s::SVector{M,T}) where {S,M,T}
+    chunks::SVector{C,T}
+    function SBitArray{S}(s::SVector{C,T}) where {S,C,T}
          S <: Tuple || error("type parameter S: $S must be a Tuple type of Int, e.g. `SBitArray{Tuple{4,5}}`")
          N = SA.tuple_length(S)
          L = SA.tuple_prod(S)
          length(s) == nchunks(T, L) || error("register/length mismatch")
-         new{S,M,T,N,L}(s)
+         new{S,C,T,N,L}(s)
     end
+end
+
+# Convenience constructors for an array of booleans, not type stable
+SBitArray{S}(a::Union{AbstractArray{Bool},NTuple{<:Any,Bool}}) where S = SBitArray{S}(UInt64, a)
+function SBitArray{S}(::Type{T}, a::Union{AbstractArray{Bool},NTuple{<:Any,Bool}}) where {S,T<:Unsigned}
+    N = SA.tuple_length(S)
+    L = SA.tuple_prod(S)
+    C = nchunks(T, L)
+    length(a) == L || error("Length of prod(S): $L does not match length of array a $(length(a))")
+    SBitArray{S,C,T,N,L}(a)
+end
+# We need the union for method ambiguities with StaticArrays
+function SBitArray{S,C,T,N,L}(
+    a::Union{StaticArray{S,Bool,L},AbstractArray{Bool},NTuple{L,Bool}}
+) where {S<:Tuple,C,T,N,L}
+    nb = nbits(T)
+    # build an ntuple for the number of complete chunks, C - 1
+    chunks = ntuple(C - 1) do c
+        # loop over bits to build the chunk
+        chunk = zero(T)
+        for b in 1:nbits(T)
+            i = (c - 1) * nb + b
+            chunk |= a[i] << (b - 1)
+        end
+        chunk
+    end
+    # Calculate the last chunk separately to avoid branching in the loop,
+    # which slows down the constructor for AbstractArray inputs.
+    lastchunk = zero(T)
+    # Use a bit mask to get the length of the last chunk
+    lastchunklen = (L - 1) & (nb - 1) + 1
+    for b in 1:lastchunklen
+        i = (C - 1) * nb + b
+        lastchunk |= a[i] << (b - 1)
+    end
+    chunks = (chunks..., lastchunk)
+    SBitArray{S}(SVector{C,T}(chunks))
 end
 
 const SBitVector{S1} = SBitArray{Tuple{S1}} where S1
 const SBitMatrix{S1,S2} = SBitArray{Tuple{S1,S2}} where {S1,S2}
 
-# Convenience constructors for an array of booleans, not type stable
-SBitArray{S}(a::AbstractArray{Bool}) where S = SBitArray{S}(UInt64, a)
-SBitArray{S}(nt::NTuple{<:Any,Bool}) where S = SBitArray{S}(UInt64, nt)
-function SBitArray{S}(::Type{T}, a::Union{AbstractArray{Bool},NTuple{<:Any,Bool}}) where {S,T<:Unsigned}
-    L = SA.tuple_prod(S)
-    M = nchunks(T, L)
-    length(a) == L || error("Length of prod(S): $L does not match length of array a $(length(a))")
-    nb = nbits(T)
-    # build an ntuple for the number of chunks M
-    chunks = ntuple(M) do c
-        # loop over bits to build the chunk
-        chunk = zero(T)
-        for i in 1:nbits(T)
-            chunk |= a[(c - 1) * nb + i] << (i - 1)
-        end
-        chunk
-    end
-    SBitArray{S}(SVector{M,T}(chunks))
-end
-
-SBitArray{S}(a::AbstractArray{Bool}) where {S} = SBitArray{S}(UInt64, a)
-
-Base.size(::SBitArray{S,M}) where {S,M} = S
+Base.size(::SBitArray{S}) where {S} = S
 Base.IndexStyle(::Type{<:SBitArray}) = IndexLinear()
 Base.@propagate_inbounds function Base.getindex(s::SBitArray{<:Any,<:Any,T}, ind::Int) where T 
     readbit(s.chunks[nchunks(T, ind)], ind)
@@ -56,7 +71,7 @@ end
 nchunks(T, l) = cld(l, nbits(T))
 nbits(T) = sizeof(T) * 8
 
-function Base.iterate(s::SBitArray{S,M,T}, state=(1, s.chunks[1])) where {S,M,T} 
+function Base.iterate(s::SBitArray{S,C,T}, state=(1, s.chunks[1])) where {S,C,T} 
     (ind, val::T) = state
     size = fieldtypes(S)
     L = prod(size)

--- a/src/StaticBitArrays.jl
+++ b/src/StaticBitArrays.jl
@@ -12,9 +12,7 @@ struct SBitArray{S,M,T<:Unsigned,N,L} <: StaticArray{S,Bool,N}
          S <: Tuple || error("type parameter S: $S must be a Tuple type of Int, e.g. `SBitArray{Tuple{4,5}}`")
          N = SA.tuple_length(S)
          L = SA.tuple_prod(S)
-         if length(s) != nchunks(T, L)
-             error("register/length mismatch")
-         end
+         length(s) == nchunks(T, L) || error("register/length mismatch")
          new{S,M,T,N,L}(s)
     end
 end
@@ -23,17 +21,21 @@ const SBitVector{S1} = SBitArray{Tuple{S1}} where S1
 const SBitMatrix{S1,S2} = SBitArray{Tuple{S1,S2}} where {S1,S2}
 
 # Convenience constructors for an array of booleans, not type stable
-function SBitArray{S}(::Type{T}, a::AbstractArray{Bool}) where {S,T<:Unsigned}
+SBitArray{S}(a::AbstractArray{Bool}) where S = SBitArray{S}(UInt64, a)
+SBitArray{S}(nt::NTuple{<:Any,Bool}) where S = SBitArray{S}(UInt64, nt)
+function SBitArray{S}(::Type{T}, a::Union{AbstractArray{Bool},NTuple{<:Any,Bool}}) where {S,T<:Unsigned}
     L = SA.tuple_prod(S)
     M = nchunks(T, L)
-    chunks = zeros(T,M)
-    ii = 0
-    for bool in a
-        ii += 1
-        ii > L && break
-        if bool
-            chunks[cld(ii,sizeof(T)*8)] += one(T) << (mod1(ii, sizeof(T)*8) - 1)
+    length(a) == L || error("Length of prod(S): $L does not match length of array a $(length(a))")
+    nb = nbits(T)
+    # build an ntuple for the number of chunks M
+    chunks = ntuple(M) do c
+        # loop over bits to build the chunk
+        chunk = zero(T)
+        for i in 1:nbits(T)
+            chunk |= a[(c - 1) * nb + i] << (i - 1)
         end
+        chunk
     end
     SBitArray{S}(SVector{M,T}(chunks))
 end
@@ -42,11 +44,12 @@ SBitArray{S}(a::AbstractArray{Bool}) where {S} = SBitArray{S}(UInt64, a)
 
 Base.size(::SBitArray{S,M}) where {S,M} = S
 Base.IndexStyle(::Type{<:SBitArray}) = IndexLinear()
-Base.getindex(s::SBitArray{S,M,T}, ind::Int) where {S,M,T} = @inbounds readbit_mod(s.chunks[cld(ind, sizeof(T)*8)], ind)
+Base.getindex(s::SBitArray{S,M,T}, ind::Int) where {S,M,T} = @inbounds readbit_mod(s.chunks[cld(ind, nbits(T))], ind)
 # moded version of readbit
-readbit_mod(x::T, loc::Int) where {T<:Unsigned} = (x >> (mod1(loc, sizeof(T)*8) - 1)) & one(T) == one(T)
+readbit_mod(x::T, loc::Int) where {T<:Unsigned} = (x >> (mod1(loc, nbits(T)) - 1)) & one(T) == one(T)
 
-nchunks(T, l) = cld(l, sizeof(T) * 8)
+nchunks(T, l) = cld(l, nbits(T))
+nbits(T) = sizeof(T) * 8
 
 function Base.iterate(s::SBitArray{S,M,T}, state=(1, s.chunks[1])) where {S,M,T} 
     (ind, val::T) = state
@@ -56,8 +59,7 @@ function Base.iterate(s::SBitArray{S,M,T}, state=(1, s.chunks[1])) where {S,M,T}
         nothing
     else
         return @inbounds (readbit_mod(val, ind), 
-            (ind+1, 
-            mod1(ind,sizeof(T)*8) == 1 ? S.chunks[cld(ind, sizeof(T)*8)] : val))
+            (ind+1, mod1(ind, nbits(T)) == 1 ? S.chunks[nchunks(T, ind)] : val))
     end
 end
 

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -4,6 +4,17 @@ using ProfileVega
 using StaticArrays
 using StaticBitArrays
 
+# Basic construction
+
+# This should compile away completely
+@btime SBitVector{70}(SVector{2, UInt64}(3, 31));
+
+# These should be real fast
+a = rand(Bool, 64)
+t = Tuple(a)
+@btime sbv = SBitVector{64}($t); # fast, just the cost of << ?
+@btime sbv = SBitVector{64}($a); # also fast
+
 # The goal here is to find the fastest way to construct a population
 function make_population(::Type{T}, x::SVector{L}, N) where {L,T}
     M = cld(L,sizeof(T)*8)
@@ -15,6 +26,7 @@ function make_population(::Type{T}, x::SVector{L}, N) where {L,T}
 end
 
 ## Tests 
+
 x = @SVector rand(100) # initial population frequencies
 @time out = make_population(UInt8, x, 10^6)
 @code_warntype  make_population(UInt8, x, 10^3)

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -7,13 +7,14 @@ using StaticBitArrays
 # Basic construction
 
 # This should compile away completely
+@btime SBitVector{64}(SVector{1, UInt64}(1));
 @btime SBitVector{70}(SVector{2, UInt64}(3, 31));
 
 # These should be real fast
 a = rand(Bool, 64)
 t = Tuple(a)
-@btime SBitVector{64}($t); # fast, just the cost of << ?
-@btime SBitVector{64}($a); # also fast
+@btime SBitVector{64}(Ref($t)[]); # fast
+@btime SBitVector{64}(Ref($a)[]); # also fast
 
 # indexing is also fast
 bv = SBitVector{64}(UInt32, a);

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -12,8 +12,14 @@ using StaticBitArrays
 # These should be real fast
 a = rand(Bool, 64)
 t = Tuple(a)
-@btime sbv = SBitVector{64}($t); # fast, just the cost of << ?
-@btime sbv = SBitVector{64}($a); # also fast
+@btime SBitVector{64}($t); # fast, just the cost of << ?
+@btime SBitVector{64}($a); # also fast
+
+# indexing is also fast
+bv = SBitVector{64}(UInt32, a);
+@btime $bv[Ref(10)[]] # Ref stops it compiling away
+@btime map(x -> !x, Ref($bv)[]) # This should return a StaticBitVector
+@btime map(x -> 2x, Ref($bv)[])
 
 # The goal here is to find the fastest way to construct a population
 function make_population(::Type{T}, x::SVector{L}, N) where {L,T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,23 +6,23 @@ v = SBitVector{70}(SVector{2, UInt64}(3, 31));
 a = SBitArray{Tuple{70}}(SVector{2, UInt64}(3, 31));
 @test v === a
 
-rbv = rand(Bool, 100)
-rbm = rand(Bool, 10, 10)
-rba = rand(Bool, 10, 10, 10)
+rbv = rand(Bool, 128)
+rbm = rand(Bool, 16, 16)
+rba = rand(Bool, 16, 16, 16)
 
 T = UInt64
 for T in [UInt8,UInt16,UInt32,UInt64] # works for all UInts
-    bv = SBitVector{100}(T, rbv);
+    bv = SBitVector{128}(T, rbv);
     @test bv isa AbstractVector
     @test bv[1] == rbv[1]
     @test all(rbv .== bv)
 
-    bm = SBitMatrix{10,10}(T, rbm);
+    bm = SBitMatrix{16,16}(T, rbm);
     @test bm isa AbstractMatrix
     @test bm[1, 2] == rbm[1, 2]
     @test all(rbm .== bm)
 
-    ba = SBitArray{Tuple{10,10,10}}(T, rba);
+    ba = SBitArray{Tuple{16,16,16}}(T, rba);
     @test ba isa AbstractArray{Bool,3}
     @test ba[1, 2, 3] == rba[1, 2, 3]
     @test all(rba .== ba)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,11 +10,12 @@ rbv = rand(Bool, 128)
 rbm = rand(Bool, 16, 16)
 rba = rand(Bool, 16, 16, 16)
 
-T = UInt64
+T = UInt8
 for T in [UInt8,UInt16,UInt32,UInt64] # works for all UInts
     bv = SBitVector{128}(T, rbv);
     @test bv isa AbstractVector
     @test bv[1] == rbv[1]
+    @test bv[end] == rbv[end]
     @test all(rbv .== bv)
 
     bm = SBitMatrix{16,16}(T, rbm);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,25 +6,28 @@ v = SBitVector{70}(SVector{2, UInt64}(3, 31));
 a = SBitArray{Tuple{70}}(SVector{2, UInt64}(3, 31));
 @test v === a
 
-rbv = rand(Bool, 128)
-rbm = rand(Bool, 16, 16)
-rba = rand(Bool, 16, 16, 16)
-
 T = UInt8
-for T in [UInt8,UInt16,UInt32,UInt64] # works for all UInts
-    bv = SBitVector{128}(T, rbv);
+l = 7
+for T in [UInt8,UInt16,UInt32,UInt64], l in (1, 2, 7, 8)
+    rbv = rand(Bool, l)
+    rbm = rand(Bool, l, l)
+    rba = rand(Bool, l, l, l)
+
+    bv = SBitVector{l}(T, rbv);
     @test bv isa AbstractVector
-    @test bv[1] == rbv[1]
+    @test bv[l] == rbv[l]
     @test bv[end] == rbv[end]
     @test all(rbv .== bv)
 
-    bm = SBitMatrix{16,16}(T, rbm);
+    bm = SBitMatrix{l,l}(T, rbm);
     @test bm isa AbstractMatrix
-    @test bm[1, 2] == rbm[1, 2]
+    @test bm[l, l] == rbm[l, l]
     @test all(rbm .== bm)
 
-    ba = SBitArray{Tuple{16,16,16}}(T, rba);
+    ba = SBitArray{Tuple{l,l,l}}(T, rba);
     @test ba isa AbstractArray{Bool,3}
-    @test ba[1, 2, 3] == rba[1, 2, 3]
+    @test ba[l, l, l] == rba[l, l, l]
     @test all(rba .== ba)
 end
+
+nothing


### PR DESCRIPTION
Ok couldn't resist. 

This PR gives us fast type-stable constructors from arrays or tuples, and fast indexing.

Things I learned:
- use bitshifts `<<` for creating chunks, no `mod`
- use `ntuple(M) do` blocks to define chunks

Currently this is broken for arrays that don't match the chunk size, will have to think of how to handle this without performance loss.